### PR TITLE
Documentation of dev tools processes

### DIFF
--- a/docs/containers.md
+++ b/docs/containers.md
@@ -11,10 +11,10 @@ See the [Podman documentation](https://podman.io/docs) to download, install, and
 
 ### Running a Python Container
 If you are running Python code with Podman, you can select a container image that already has Python installed, such as `docker.io/library/python:3.12`.
-- **Note:** Sometimes the `python:3.12` container has trouble installing packages that use h5py. 
-This can be installed by running the following commands in the container's Terminal:
+
+**Note:** The `python:3.12` container does not appear to have `h5py` installed, which can cause trouble with installing some packages.
+To install `h5py`, run the following commands in the *container's* Terminal:
 ```
 apt update
 apt-get install libhdf5-dev
 ```
-After that completes, there should be no trouble running a `pip install` for a particular package.

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -1,0 +1,20 @@
+# Containers 
+
+This file will include documentation on using containerization development tools, such as Podman. 
+It will be expanded and refined over time.
+
+## Using Podman
+Podman is a free container management tool that is very helpful and user-friendly.
+
+### Getting Started
+See the [Podman documentation](https://podman.io/docs) to download, install, and get started with Podman.
+
+### Running a Python Container
+If you are running Python code with Podman, you can select a container image that already has Python installed, such as `docker.io/library/python:3.12`.
+- **Note:** Sometimes the `python:3.12` container has trouble installing packages that use h5py. 
+This can be installed by running the following commands in the container's Terminal:
+```
+apt update
+apt-get install libhdf5-dev
+```
+After that completes, there should be no trouble running a `pip install` for a particular package.

--- a/docs/dev-tools/containers.md
+++ b/docs/dev-tools/containers.md
@@ -12,7 +12,7 @@ See the [Podman documentation](https://podman.io/docs) to download, install, and
 ### Running a Python Container
 If you are running Python code with Podman, you can select a container image that already has Python installed, such as `docker.io/library/python:3.12`.
 
-**Note:** If the package you want to install uses `h5py`, you may need to run the following commands in the *container's* Terminal before installing the desired package:
+**Troubleshooting Note:** If the package you want to install uses `h5py`, you may need to run the following commands in the *container's* Terminal before installing the desired package:
 ```
 apt update
 apt-get install libhdf5-dev

--- a/docs/dev-tools/containers.md
+++ b/docs/dev-tools/containers.md
@@ -18,3 +18,9 @@ To install `h5py`, run the following commands in the *container's* Terminal:
 apt update
 apt-get install libhdf5-dev
 ```
+
+## Using Dev Containers
+Development containers are Docker containers configured for development that can be launched in a codespace, such as GitHub Codespaces or VSCode.
+The dev container build instructions live in the `.devcontainer/` folder in the `devcontainer.json` file, and the container can be built from existing images or from a custom Dockerfile included in the project.
+
+For more information, see GitHub's [Introduction to dev containers](https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/adding-a-dev-container-configuration/introduction-to-dev-containers) and VSCode's [Developing inside a Container](https://code.visualstudio.com/docs/devcontainers/containers).

--- a/docs/dev-tools/github-actions.md
+++ b/docs/dev-tools/github-actions.md
@@ -17,6 +17,7 @@ GitHub Docs explain the reason as follows:
 > Pinning an action to a full length commit SHA is currently the only way to use an action as an immutable release.
 > Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository, as they would need to generate a SHA-1 collision for a valid Git object payload. 
 > When selecting a SHA, you should verify it is from the action's repository and not a repository fork.
+
 For example, use
 ```
 steps:
@@ -33,8 +34,10 @@ For more information see [Using third-party actions](https://docs.github.com/en/
 
 ### Artifact attestation
 GitHub Docs describe [artifact attestation](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) as follows:
+
 > Artifact attestations enable you to create unfalsifiable provenance and integrity guarantees for the software you build. 
 > In turn, people who consume your software can verify where and how your software was built.
+
 If your workflow generates an artifact that will only be used internally (e.g., by the workflow itself), then attestation isn't necessary. 
 But if your workflow outputs will be used by others, you should include artifact attestation (e.g., with [`actions/attest-build-provenance`](https://github.com/actions/attest-build-provenance))
 

--- a/docs/python-development.md
+++ b/docs/python-development.md
@@ -1,0 +1,10 @@
+# Python Development
+
+This file will include documentation on developing Python packages, such as using Poetry.
+It will be expanded and refined over time.
+
+## Poetry
+Poetry is a useful dependency management and packaging system for Python.
+
+### Getting Started
+See the [Poetry documentation](https://python-poetry.org/docs/) to install and get started with Poetry.


### PR DESCRIPTION
Creates the basic folders and files for documenting development tools and processes:
- `docs/` folder to store documentation
- `python-development.md` with initial details for developing python projects and packages
- `dev-tools/` folder to store documentation on specific tools for development
- `containers.md` with initial details on using Podman, running containers, and using dev containers