### PR TITLE
12 Create documentation for GitHub actions

### DIFF
--- a/docs/dev-tools/example-workflows/pre-commit-r-project/pre-commit-config.yaml
+++ b/docs/dev-tools/example-workflows/pre-commit-r-project/pre-commit-config.yaml
@@ -1,0 +1,28 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+# General-purpose pre-commit hooks
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files
+    -   id: detect-private-key
+
+# Pre-commit hooks for R projects
+-   repo: https://github.com/lorenzwalthert/precommit
+    rev: v0.4.3
+    hooks:
+      - id: style-files
+        args:
+          [
+            '--ignore-start="^# styler: off$"',
+            '--ignore-stop="^# styler: on$"',
+            '--strict=FALSE',
+            '--cache-root=styler-perm'
+            ]
+      - id: lintr
+        args: [--warn_only]
+        verbose: true

--- a/docs/dev-tools/example-workflows/pre-commit-r-project/pre-commit.yaml
+++ b/docs/dev-tools/example-workflows/pre-commit-r-project/pre-commit.yaml
@@ -1,0 +1,40 @@
+# Pre-commit workflow for R project
+name: Pre-commit
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  pre-commit:
+
+    name: Pre-commit
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v3
+
+      - name: Cache R packages for pre-commit (live in renv)
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/R/renv
+          key: r-precommit-cache|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+
+      # Notice this step depends on what
+      # https://github.com/lorenzwalthert/precommit has as
+      # R version in renv.lock. GHA ubuntu-latest runner comes
+      # with R 4.4.1, which is the same as in renv.lock. If that
+      # changes, caching will not work as it will be loading a
+      # different version of R.
+      - name: Run pre-commit hooks
+        uses: pre-commit/action@v3.0.1

--- a/docs/dev-tools/github-actions.md
+++ b/docs/dev-tools/github-actions.md
@@ -1,19 +1,16 @@
 # GitHub Actions
 
-Information on building and running GitHub Actions (GHA).
-TODO: Link General Documentation
-TODO: Link Workflow Syntax (cheatsheet)
+Information on building and running GitHub Actions.
 
-## Configuring Project's GHA Settings
-TODO: What needs to be done here
+## Resources
+- [GitHub Actions documentation](https://docs.github.com/en/actions)
+- [Workflow syntax for GitHub Actions](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions)
 
-## Suggestions
-
-### Security Practices
+## Suggested Security Practices
 See [Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions) for good security practices when using GitHub Actions.
 Below we highlight specific practices that can be easily overlooked.
 
-#### Using full length commit SHA
+### Using full length commit SHA
 When using a third-party GitHub Action (such as any of those described in [Supporting Actions](#supporting-actions) below), pin the action to a full length commit SHA.
 
 GitHub Docs explain the reason as follows:
@@ -34,14 +31,14 @@ steps:
 ```
 For more information see [Using third-party actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).
 
-#### Artifact attestation
+### Artifact attestation
 GitHub Docs describe [artifact attestation](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) as follows:
 > Artifact attestations enable you to create unfalsifiable provenance and integrity guarantees for the software you build. 
 > In turn, people who consume your software can verify where and how your software was built.
 If your workflow generates an artifact that will only be used internally (e.g., by the workflow itself), then attestation isn't necessary. 
 But if your workflow outputs will be used by others, you should include artifact attestation (e.g., with [`actions/attest-build-provenance`](https://github.com/actions/attest-build-provenance))
 
-## Examples
+## Github Actions Examples
 
 ### Supporting Actions
 These can be included in your workflow file to execute certain tasks, rather than building them from scratch.

--- a/docs/dev-tools/github-actions.md
+++ b/docs/dev-tools/github-actions.md
@@ -10,14 +10,36 @@ TODO: What needs to be done here
 ## Suggestions
 
 ### Security Practices
-TODO: Reasoning
-TODO: Using full length commit SHA described [here](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)
-TODO: Link to more information
+See [Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions) for good security practices when using GitHub Actions.
+Below we highlight specific practices that can be easily overlooked.
 
-### Artifact attestation
-TODO: Reasoning for attestation
-TODO: Example action for doing it
-TODO: Link to more information: [Artifact attestation](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds)
+#### Using full length commit SHA
+When using a third-party GitHub Action (such as any of those described in [Supporting Actions](#supporting-actions) below), pin the action to a full length commit SHA.
+
+GitHub Docs explain the reason as follows:
+> Pinning an action to a full length commit SHA is currently the only way to use an action as an immutable release.
+> Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository, as they would need to generate a SHA-1 collision for a valid Git object payload. 
+> When selecting a SHA, you should verify it is from the action's repository and not a repository fork.
+For example, use
+```
+steps:
+    - name: Log in to the Container registry
+      uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+```
+instead of
+```
+steps:
+    - name: Log in to the Container registry
+      uses: docker/login-action
+```
+For more information see [Using third-party actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).
+
+#### Artifact attestation
+GitHub Docs describe [artifact attestation](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) as follows:
+> Artifact attestations enable you to create unfalsifiable provenance and integrity guarantees for the software you build. 
+> In turn, people who consume your software can verify where and how your software was built.
+If your workflow generates an artifact that will only be used internally (e.g., by the workflow itself), then attestation isn't necessary. 
+But if your workflow outputs will be used by others, you should include artifact attestation (e.g., with [`actions/attest-build-provenance`](https://github.com/actions/attest-build-provenance))
 
 ## Examples
 
@@ -27,10 +49,12 @@ Using existing actions will simplify and strengthen your workflow.
 
 #### General Purpose
 - Checkout repo: [`actions/checkout`](https://github.com/actions/checkout)
-- Generation attestation for workflow artifacts: [`actions/attest-build-provenance`](https://github.com/actions/attest-build-provenance)
 - Setup specific Python version for workflow: [`actions/setup-python`](https://github.com/actions/setup-python)
-- Cache dependencies and build outputs: [`actions/cache`](https://github.com/actions/cache)
 - Run pre-commit: [`pre-commit/action`](https://github.com/pre-commit/action)
+
+#### Working with Workflow Outputs
+- Generation attestation for workflow artifacts: [`actions/attest-build-provenance`](https://github.com/actions/attest-build-provenance)
+- Cache dependencies and build outputs: [`actions/cache`](https://github.com/actions/cache)
 
 #### Building Docker Images
 - Login to container registry: [`docker/login-action`](https://github.com/docker/login-action)

--- a/docs/dev-tools/github-actions.md
+++ b/docs/dev-tools/github-actions.md
@@ -1,0 +1,47 @@
+# GitHub Actions
+
+Information on building and running GitHub Actions (GHA).
+TODO: Link General Documentation
+TODO: Link Workflow Syntax (cheatsheet)
+
+## Configuring Project's GHA Settings
+TODO: What needs to be done here
+
+## Suggestions
+
+### Security Practices
+TODO: Reasoning
+TODO: Using full length commit SHA described [here](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)
+TODO: Link to more information
+
+### Artifact attestation
+TODO: Reasoning for attestation
+TODO: Example action for doing it
+TODO: Link to more information: [Artifact attestation](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds)
+
+## Examples
+
+### Supporting Actions
+These can be included in your workflow file to execute certain tasks, rather than building them from scratch.
+Using existing actions will simplify and strengthen your workflow.
+
+#### General Purpose
+- Checkout repo: [`actions/checkout`](https://github.com/actions/checkout)
+- Generation attestation for workflow artifacts: [`actions/attest-build-provenance`](https://github.com/actions/attest-build-provenance)
+- Setup specific Python version for workflow: [`actions/setup-python`](https://github.com/actions/setup-python)
+- Cache dependencies and build outputs: [`actions/cache`](https://github.com/actions/cache)
+- Run pre-commit: [`pre-commit/action`](https://github.com/pre-commit/action)
+
+#### Building Docker Images
+- Login to container registry: [`docker/login-action`](https://github.com/docker/login-action)
+- Extract metadata from Github for Docker: [`docker/metadata-action`](https://github.com/docker/metadata-action)
+- Build and push Docker image: [`docker/build-push-action`](https://github.com/docker/build-push-action)
+
+#### GitHub Pages
+- Setup Pages: [`actions/configure-pages`](https://github.com/actions/configure-pages)
+- Package and upload artifact that can be deployed to Pages: [`actions/upload-pages-artifact`](https://github.com/actions/upload-pages-artifact)
+- Deploy to Pages: [`actions/deploy-pages`](https://github.com/actions/deploy-pages)
+
+### Example Workflow Files 
+The [`example-workflows/`](./example-workflows/) folder contains example workflow files for reference.
+Additional examples can be found in the [`epiworld-forecasts`](https://github.com/EpiForeSITE/epiworld-forecasts/) repo.


### PR DESCRIPTION
Add the following:
- `github-actions.md`: Documentation on GitHub Actions
- `docs/dev-tools/example-workflows/pre-commit-r-project/` containing `pre-commit-config.yaml` and `pre-commit-config.yaml`